### PR TITLE
remove HAWA link

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,6 @@ To ensure the quickest possible response to a question you are encouraged to lit
 * [Flask Websockets for Chat Features](https://hackmd.io/oTn-ZTjcQRO5Ghbv9tO9ug)
 * [Helpful Heroku Tips](https://github.com/whitnessme/helpful-heroku-tips)
 * [Easy Modals Using React Context!](https://github.com/whitnessme/context-modal-instructions)
-* [HAWA: easy wiki doc generation for Routes and User Stories](https://hawa-beta.herokuapp.com/)
 <!-- * [Free Development Design Resources](https://github.com/bradtraversy/design-resources-for-developers#stock-photos) -->
 
 <!-- [New Asking Questions Guide with Emojis](https://docs.google.com/document/d/1LMgYJ0TgZBdbE-D7rEQLAXyRWesSJl5aR_H2KPUJhCQ/edit#) -->


### PR DESCRIPTION
Hi Tom,

No one has used HAWA in a couple of cohorts, so I am going to move off of the relatively expensive Heroku instances I'm on, and discontinue support. I also started a position last week, so it served its other purpose as well. 😊

Hope things are well with you! Saw your LinkedIn post — good luck out there!

Cheers,

Nick